### PR TITLE
Regex path

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -21,24 +21,6 @@ exports.isValidName = function (name) {
 };
 
 /**
- * Check if a route path is valid or not
- * A valid path is:
- *   '/', or
- *   '/token_1/token_2/.../token_n', where token_i consists of alphanumerics, dashes, or underscores
- * @author William Gozali <will.gozali@cermati.com>
- * @param path
- */
-exports.isValidPathForNamedRoute = function (path) {
-  if (typeof path != 'string') {
-    return false;
-  }
-  if (path === '/') {
-    return true;
-  }
-  return path.match(/^(\/:?[-_.a-zA-Z0-9]+)+$/) !== null;
-};
-
-/**
  * Convert given "slice of pattern" to token which is easier to use
  * @author William Gozali <will.gozali@cermati.com>
  * @example
@@ -131,9 +113,6 @@ exports.register = function (routeTable, nameHierarchy, pathHierarchy) {
 
   if (routeTable[name] && (pattern !== routeTable[name].pattern)) {
     throw new Error('There are duplicates in route name: ' + name);
-  }
-  if (!self.isValidPathForNamedRoute(pattern)) {
-    throw new Error('Generated pattern is malformed, check the routing implementation: ' + pattern);
   }
 
   routeTable[name] = {

--- a/index.js
+++ b/index.js
@@ -24,6 +24,8 @@ var util = require('util');
 var helper = require('./helper');
 var constants = require('./constants');
 
+var pathToRegexp = require('path-to-regexp');
+
 var baseUrl;
 var routeTable;
 var PUSH = constants.PUSH;
@@ -134,9 +136,6 @@ function add() {
 
     if (!helper.isValidName(name)) {
       throw new Error('Invalid route name: ' + name);
-    }
-    if (!helper.isValidPathForNamedRoute(path)) {
-      throw new Error('Invalid path for named route: ' + path + ', it won\'t make sense for urlFor');
     }
   } else {
     // No name provided
@@ -293,27 +292,12 @@ function urlFor(routeName, params, queries) {
     throw new Error('Attempted to use undefined routeName: ' + routeName);
   }
 
-  var url = routeTable[routeName].tokens.map(function (token) {
-    var filledToken;
-
-    if (!token.input) {
-      filledToken = token.text;
-    } else {
-      var param = params[token.text];
-      if ((param === undefined) || (param === null) || (param === '')) {
-        var message = util.format('Incomplete parameter for pattern: %s = %s', routeTable[routeName].pattern, token.text);
-        throw new Error(message);
-      }
-      filledToken = params[token.text];
-    }
-
-    return filledToken;
-  }).join('/');
+  var toPath = pathToRegexp.compile(routeTable[routeName].pattern);
+  var url= toPath(params);
 
   if (queries) {
     url = util.format('%s?%s', url, querystring.stringify(queries));
   }
-
   return url;
 }
 

--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
   "author": "William Gozali <will.gozali@cermati.com>",
   "license": "MIT",
   "dependencies": {
-    "path-to-regexp": "^1.5.3"
+    "path-to-regexp": "~1.5.3"
   },
   "devDependencies": {
     "chai": "~3.5.0",
+    "express": "~4.14.0",
     "mocha": "~2.5.3",
     "rewire": "~2.5.1",
     "sinon": "~1.17.4",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
   ],
   "author": "William Gozali <will.gozali@cermati.com>",
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "path-to-regexp": "^1.5.3"
+  },
   "devDependencies": {
     "chai": "~3.5.0",
     "mocha": "~2.5.3",

--- a/tests/helper.spec.js
+++ b/tests/helper.spec.js
@@ -42,58 +42,6 @@ describe('router/helper.js', function () {
     });
   });
 
-  describe('.isValidPathForNamedRoute()', function () {
-    context('when given valid path', function () {
-      it('should return true for root', function () {
-        expect(routeHelper.isValidPathForNamedRoute('/')).to.be.true;
-      });
-
-      it('should return true for usual path', function () {
-        expect(routeHelper.isValidPathForNamedRoute('/path')).to.be.true;
-        expect(routeHelper.isValidPathForNamedRoute('/with/number/12/wow')).to.be.true;
-        expect(routeHelper.isValidPathForNamedRoute('/with-dash')).to.be.true;
-        expect(routeHelper.isValidPathForNamedRoute('/with_underscore')).to.be.true;
-        expect(routeHelper.isValidPathForNamedRoute('/CAPITAL')).to.be.true;
-        expect(routeHelper.isValidPathForNamedRoute('/MixEd')).to.be.true;
-        expect(routeHelper.isValidPathForNamedRoute('/more/than/one')).to.be.true;
-        expect(routeHelper.isValidPathForNamedRoute('/with/:input')).to.be.true;
-        expect(routeHelper.isValidPathForNamedRoute('/with/:more/:input')).to.be.true;
-        expect(routeHelper.isValidPathForNamedRoute('/bun/:meat/bun/:cheese/bun')).to.be.true;
-        expect(routeHelper.isValidPathForNamedRoute('/can/have/:input/and/:input/again')).to.be.true;
-        expect(routeHelper.isValidPathForNamedRoute('/with-extension.xml')).to.be.true;
-      });
-    });
-
-    context('when given invalid path', function () {
-      it('should return false for falsy path', function () {
-        expect(routeHelper.isValidPathForNamedRoute('')).to.be.false;
-        expect(routeHelper.isValidPathForNamedRoute(undefined)).to.be.false;
-        expect(routeHelper.isValidPathForNamedRoute(null)).to.be.false;
-      });
-
-      it('should return false for malformed path', function () {
-        expect(routeHelper.isValidPathForNamedRoute('//')).to.be.false;
-        expect(routeHelper.isValidPathForNamedRoute('no-slash')).to.be.false;
-        expect(routeHelper.isValidPathForNamedRoute('/slash-in-the/end/')).to.be.false;
-        expect(routeHelper.isValidPathForNamedRoute('//multiple//slash')).to.be.false;
-        expect(routeHelper.isValidPathForNamedRoute('/contains space')).to.be.false;
-      });
-
-      it('should return false for malformed input token', function () {
-        expect(routeHelper.isValidPathForNamedRoute('/:colon:again')).to.be.false;
-        expect(routeHelper.isValidPathForNamedRoute('/no-name/:')).to.be.false;
-      });
-
-      it('should return false for path with non alphanumeric characters, dash, or underscore', function () {
-        expect(routeHelper.isValidPathForNamedRoute('/wildcard*')).to.be.false;
-        expect(routeHelper.isValidPathForNamedRoute('/another/wildcard*')).to.be.false;
-        expect(routeHelper.isValidPathForNamedRoute('/wildcard*/in/middle')).to.be.false;
-        expect(routeHelper.isValidPathForNamedRoute('/much/(wow)+')).to.be.false;
-        expect(routeHelper.isValidPathForNamedRoute('/mega?/\w+/r?gex')).to.be.false;
-      });
-    });
-  });
-
   describe('.toToken()', function () {
     context('when given non input field', function () {
       it('should return just text', function () {

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -93,6 +93,42 @@ describe('router/index.js', function () {
     });
   });
 
+  describe('check path with regex use real express app', function () {
+    var express = require('express');
+    var expressApp = express();
+    var sampleMiddleware;
+    var router;
+    var useSpy;
+
+    before('register express app', function () {
+      useSpy = sinon.spy(expressApp, 'use');
+      router = require('../index')(expressApp);
+    });
+
+    before('register test middleware', function () {
+      sampleMiddleware = function (req, res, next) {
+        return next();
+      };
+    });
+
+    context('register paths that contain regex', function () {
+      it('should accept valid pattern', function () {
+        expect(function () {
+          // See https://expressjs.com/en/guide/routing.html
+          router.use(/.*fly?/, sampleMiddleware)
+        }).to.not.throw(Error);
+        expect(useSpy).to.have.been.calledWith(/.*fly?/, [sampleMiddleware]);
+      });
+      it('should throw error for invalid pattern', function () {
+        expect(function () {
+          // See https://github.com/expressjs/express/issues/2034
+          router.use('/video/:alias?/(category/:category)?/', sampleMiddleware);
+        }).to.throw(Error);
+        expect(useSpy).to.have.been.calledWith('/video/:alias?/(category/:category)?/', [sampleMiddleware]);
+      });
+    });
+  });
+
   describe('.buildRouteTable()', function () {
     var PUSH;
     var POP;

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -270,6 +270,14 @@ describe('router/index.js', function () {
         pattern: '/foo/:input/bun/:input',
         tokens: [{text: ''}, {text: 'foo'}, {text: 'input', input: true}, {text: 'bun'}, {text: 'input', input: true}]
       };
+      routeTable['flights.fromto'] = {
+        pattern: '/flights/:from-:to',
+        tokens: [{text: ''}, {text: 'flights'}, {text: 'from', input: true}, {text: '-'}, {text: 'to', input: true}]
+      };
+      routeTable['flights.number'] = {
+        pattern: '/flights/num-:number(\\d+)',
+        tokens: [{text: ''}, {text: 'flights'}, {text: 'num-'}, {text: 'code', input: true}]
+      };
 
       revert = router.__set__('routeTable', routeTable);
       urlFor = router.urlFor;
@@ -343,6 +351,20 @@ describe('router/index.js', function () {
 
         expect(function () {
           urlFor('foo.list-category', {category: undefined});
+        }).to.throw(Error);
+      });
+    });
+
+    context('when given path with regexes', function () {
+      it('should return correct path', function () {
+        expect(urlFor('flights.fromto', {from: 'CGK', to: 'DPS'})).to.equal('/flights/CGK-DPS');
+      });
+      it('should return correct path when params have digit regex', function () {
+        expect(urlFor('flights.number', {number: 30})).to.equal('/flights/num-30');
+      });
+      it('should return error when params have digit regex but given string', function () {
+        expect(function () {
+          urlFor('flights.number', {number: 'test'})
         }).to.throw(Error);
       });
     });


### PR DESCRIPTION
- remove `.isValidPathForNamedRoute()` function
- use `path-to-regexp` in urlFor to return url for pattern that contains regexes
- I use express app for testing to make sure it's running on real path regex pattern
