### PR TITLE
addMapping() function to map route to a name without register it to express routing

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,9 @@ var routerBase = {
  *   router.get('list', '/', require('./views/list'));
  *   router.get('detail', '/:title', require('./views/detail'));
  *   router.post('save', '/:title', middleware.requireAdmin, require('./views/save')); // Can add middleware
+ *
+ *   or we can just register name without middleware to route:
+ *   router.addMapping('route.all', /route/*);
  */
 var router = function (app) {
   // Inherit other method from app
@@ -81,6 +84,7 @@ var router = function (app) {
   // Extend with additional functions
   router.use = add.bind(null, 'use', app);
   router.all = add.bind(null, 'all', app);
+  router.addMapping = add.bind(null, null, app);
   router.buildRouteTable = buildRouteTable.bind(null, app);
 
   return router;
@@ -158,19 +162,22 @@ function add() {
     });
   }
 
-  // Register this for express to do its stuff
-  app[method](path, middlewares);
+  // Method will be null if we use addMapping()
+  if (method) {
+    // Register this for express to do its stuff
+    app[method](path, middlewares);
 
-  var routeController = middlewares[middlewares.length - 1];
-  if (Array.isArray(routeController.routeTraversal)) {
-    /*
-     As with our function signature, the last element of the middlewares is assumed to be
-     the "handler" for the controller logic.
-     Even if it is not (could be just a middleware for login guard), then routeController.routeTraversal
-     is guaranteed to be undefined, it won't even enter this loop
-     */
-    for (var i = 0; i < routeController.routeTraversal.length; i++) {
-      app.routeTraversal.push(routeController.routeTraversal[i]);
+    var routeController = middlewares[middlewares.length - 1];
+    if (Array.isArray(routeController.routeTraversal)) {
+      /*
+       As with our function signature, the last element of the middlewares is assumed to be
+       the "handler" for the controller logic.
+       Even if it is not (could be just a middleware for login guard), then routeController.routeTraversal
+       is guaranteed to be undefined, it won't even enter this loop
+       */
+      for (var i = 0; i < routeController.routeTraversal.length; i++) {
+        app.routeTraversal.push(routeController.routeTraversal[i]);
+      }
     }
   }
 

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -246,7 +246,12 @@ describe('router/index.js', function () {
           {operation: PUSH, name: '3', path: '/3'},
           {operation: POP, name: '3', path: '/3'},
           {operation: POP, name: '2', path: '/2'},
-          {operation: POP, name: '1', path: '/1'}
+          {operation: POP, name: '1', path: '/1'},
+
+          {operation: PUSH, name: 'reg', path: '/reg'},
+          {operation: PUSH, name: 'all', path: '/*'},
+          {operation: POP, name: 'all', path: '/*'},
+          {operation: POP, name: 'reg', path: '/reg'}
         ];
 
         router.buildRouteTable();
@@ -268,8 +273,36 @@ describe('router/index.js', function () {
         expect(routeTable['1.1-end'].pattern).to.equal('/1/end');
         expect(routeTable['1.1-bypass.3'].pattern).to.equal('/1/3');
         expect(routeTable['1.2.3'].pattern).to.equal('/1/2/3');
+
+        expect(routeTable['reg.all'].pattern).to.equal('/reg/*');
       });
     });
+  });
+
+  describe('.addMapping()', function () {
+    var router;
+    var routeTable;
+
+    before('initialize router & build route table', function () {
+      var app = {};
+      var wiredRouter = rewire('../index');
+      router = wiredRouter(app);
+
+      router.addMapping('reg.all', '/reg/*');
+      router.addMapping('reg.product', '/reg/:id');
+      router.addMapping('reg.product.all', '/reg/:id/*');
+
+      router.buildRouteTable();
+      routeTable = router.getRouteTable();
+    });
+
+    context('routes should be registered', function () {
+      it('should registered routes', function () {
+        expect(routeTable['reg.all']).to.equal('/reg/*');
+        expect(routeTable['reg.product']).to.equal('/reg/:id');
+        expect(routeTable['reg.product.all']).to.equal('/reg/:id/*');
+      });
+    })
   });
 
   describe('.urlFor()', function () {


### PR DESCRIPTION
I add `addMapping()` method, so now we can register a route without any controller or middlewares. The usage is as follow:

```
var router = require('route-label')(app);
router.addMapping('foo.all', '/foo/*');
router.buildRouteTable();
```

Then we can call with route table:

```
var routeTable = router.getRouteTable();
routeTable[foo.all] -> /foo/*
```
